### PR TITLE
Improve base typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="大模型日志分析工具 - 分析和可视化机器学习训练日志中的损失函数和梯度范数数据" />
     <meta name="keywords" content="机器学习,日志分析,数据可视化,损失函数,梯度范数" />

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,17 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 /* Accessibility improvements */
 @layer base {
+  body {
+    font-family: 'Noto Sans SC', ui-sans-serif, system-ui, Helvetica Neue, Arial, Noto Sans, sans-serif;
+    background-color: #f9fafb;
+    color: #1f2937;
+    line-height: 1.5;
+  }
   /* Screen reader only content */
   .sr-only {
     position: absolute;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,11 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['"Noto Sans SC"', 'ui-sans-serif', 'system-ui', 'Helvetica Neue', 'Arial', 'Noto Sans', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- import Google Font Noto Sans SC for better Chinese rendering
- set base body styles with Noto Sans font
- configure Tailwind to use the new font as default sans

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f0259a1a4832d9c07ed7fe94c266c