### PR TITLE
Improve chart axis display

### DIFF
--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -314,13 +314,20 @@ export default function ChartContainer({
         title: { display: true, text: 'Step' },
         min: xRange.min,
         max: xRange.max,
-        bounds: 'data'
+        bounds: 'data',
+        grace: '2%',
+        ticks: {
+          callback: function (value) {
+            return Math.round(value);
+          }
+        }
       },
       y: {
         type: 'linear',
         display: true,
         title: { display: true, text: 'Value' },
         bounds: 'data',
+        grace: '5%',
         ticks: {
           callback: function (value) {
             return Number(value.toPrecision(2));

--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -315,7 +315,6 @@ export default function ChartContainer({
         min: xRange.min,
         max: xRange.max,
         bounds: 'data',
-        grace: '2%',
         ticks: {
           callback: function (value) {
             return Math.round(value);
@@ -327,7 +326,7 @@ export default function ChartContainer({
         display: true,
         title: { display: true, text: 'Value' },
         bounds: 'data',
-        grace: '5%',
+        grace: '20%',
         ticks: {
           callback: function (value) {
             return Number(value.toPrecision(2));


### PR DESCRIPTION
## Summary
- give `ChartContainer` axis some breathing room using `grace`
- ensure x-axis tick labels show integers even when range uses floats

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687f4667db60832db3173359b2d1ed5d