### PR TITLE
Fix PRs overwriting root site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Summary
- run the deploy workflow only when pushing to main

The workflow previously triggered on pull_request events. That meant PR builds
were deployed to the `gh-pages` branch and overwrote the main site.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68833df4f740832db1de81069d494756