### PR TITLE
Add duplicate file replacement

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { ComparisonControls } from './components/ComparisonControls';
 import { Header } from './components/Header';
 import { FileConfigModal } from './components/FileConfigModal';
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { mergeFilesWithReplacement } from './utils/mergeFiles.js';
 
 function App() {
   const [uploadedFiles, setUploadedFiles] = useState([]);
@@ -54,7 +55,7 @@ function App() {
         }
       }
     }));
-    setUploadedFiles(prev => [...prev, ...filesWithDefaults]);
+    setUploadedFiles(prev => mergeFilesWithReplacement(prev, filesWithDefaults));
   }, [globalParsingConfig]);
 
   // 全局文件处理函数

--- a/src/utils/__tests__/mergeFiles.test.js
+++ b/src/utils/__tests__/mergeFiles.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { mergeFilesWithReplacement } from '../mergeFiles.js';
+
+describe('mergeFilesWithReplacement', () => {
+  it('replaces file with same name and keeps config', () => {
+    const prev = [{ name: 'log1.txt', id: '1', enabled: true, config: { a: 1 }, content: 'old' }];
+    const newFile = { name: 'log1.txt', id: '2', enabled: true, config: {}, content: 'new' };
+    const result = mergeFilesWithReplacement(prev, [newFile]);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('new');
+    expect(result[0].config).toEqual({ a: 1 });
+  });
+
+  it('adds new file when name does not exist', () => {
+    const prev = [{ name: 'log1.txt', id: '1', enabled: true, config: {}, content: 'old' }];
+    const newFile = { name: 'log2.txt', id: '2', enabled: true, config: {}, content: 'new' };
+    const result = mergeFilesWithReplacement(prev, [newFile]);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/src/utils/mergeFiles.js
+++ b/src/utils/mergeFiles.js
@@ -1,0 +1,13 @@
+export function mergeFilesWithReplacement(prevFiles, newFiles) {
+  const updated = [...prevFiles];
+  newFiles.forEach(file => {
+    const idx = updated.findIndex(f => f.name === file.name);
+    if (idx !== -1) {
+      const existing = updated[idx];
+      updated[idx] = { ...file, enabled: existing.enabled, config: existing.config };
+    } else {
+      updated.push(file);
+    }
+  });
+  return updated;
+}


### PR DESCRIPTION
## Summary
- replace existing file data when uploading files with the same name
- keep existing config for replaced files
- test mergeFilesWithReplacement

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688484264020832d8be30e613379b0c8