### PR TITLE
Enable zipped build artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,15 @@ jobs:
     - name: Build
       run: npm run build
 
+    - name: Package build output
+      run: zip -r dist.zip dist
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-package
+        path: dist.zip
+
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 2. 在仓库设置中启用 GitHub Pages
 3. 选择 GitHub Actions 作为部署源
 4. 推送代码时将自动触发构建和部署
+5. 部署完成后，可在 `Deploy to GitHub Pages` 工作流中下载自动生成的 `dist.zip` 以进行本地部署
 
 ## 📝 使用指南
 


### PR DESCRIPTION
## Summary
- build workflow now zips the `dist` folder and uploads it as an artifact
- document where to download the `dist.zip` file after deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68872728eee4832dbf76744c166faa98