### PR TITLE
Add Vercel deploy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@
 4. 推送代码时将自动触发构建和部署
 5. 部署完成后，可在 `Deploy to GitHub Pages` 工作流中下载自动生成的 `dist.zip` 以进行本地部署
 
+### 使用 Vercel 部署
+
+项目也支持部署到 [Vercel](https://vercel.com)。仓库已包含 `vercel.json` 配置文件，默认使用 `@vercel/static-build` 构建站点并将 `dist` 目录作为输出。部署步骤如下：
+
+1. 安装 Vercel CLI：`npm i -g vercel`
+2. 在项目根目录运行 `vercel`，根据提示完成初始化
+3. 之后每次 `git push` 都会自动触发构建并部署到 Vercel
+
 ## 📝 使用指南
 
 ### 🎯 快速上手

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@
 
 ### 使用 Vercel 部署
 
+如果想要快速体验，可以点击下方按钮一键部署：
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/JavaZeroo/log-parser)
+
 项目也支持部署到 [Vercel](https://vercel.com)。仓库已包含 `vercel.json` 配置文件，默认使用 `@vercel/static-build` 构建站点并将 `dist` 目录作为输出。部署步骤如下：
 
 1. 安装 Vercel CLI：`npm i -g vercel`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,12 +4,12 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 
 export default [
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage'] },
   {
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, ...globals.node },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
+  ],
+  "rewrites": [
+    { "source": "(/.*)", "destination": "/index.html" }
+  ]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,11 +5,9 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  // Use a relative base path so the built site works
-  // when deployed to subfolders such as PR previews.
-  // This still works for the main site hosted at the
-  // repository root.
-  base: './',
+  // Use a relative base path for GitHub Pages.
+  // Switch to absolute path when deploying on Vercel.
+  base: process.env.VERCEL ? '/' : './',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- add instructions for deploying on Vercel
- support Node globals in ESLint and ignore coverage directory
- detect Vercel environment in vite config
- add `vercel.json` for static build

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688836606530832d9f7aff8db6bbd689