### PR TITLE
Use matplotlib-inspired color cycle

### DIFF
--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -176,7 +176,19 @@ export default function ChartContainer({
     }
   }, [parsedData, onXRangeChange]);
 
-  const colors = ['#ef4444', '#3b82f6', '#10b981', '#f59e0b', '#8b5cf6', '#f97316'];
+  // Use a lower saturation palette inspired by matplotlib
+  const colors = [
+    '#1f77b4', // blue
+    '#ff7f0e', // orange
+    '#2ca02c', // green
+    '#d62728', // red
+    '#9467bd', // purple
+    '#8c564b', // brown
+    '#e377c2', // pink
+    '#7f7f7f', // gray
+    '#bcbd22', // olive
+    '#17becf'  // cyan
+  ];
   const createChartData = dataArray => ({
     datasets: dataArray.map((item, index) => {
       const color = colors[index % colors.length];


### PR DESCRIPTION
## Summary
- switch default chart colors to matplotlib's color cycle for lower saturation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b0a3dcc90832da02324edb64685fd