### PR TITLE
feat: support step keyword alignment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,8 @@ function App() {
   const [xRange, setXRange] = useState({ min: undefined, max: undefined });
   const [maxStep, setMaxStep] = useState(0);
   const [sidebarVisible, setSidebarVisible] = useState(true);
+  const [alignSteps, setAlignSteps] = useState(false);
+  const [stepKeyword, setStepKeyword] = useState('step:');
 
   const handleFilesUploaded = useCallback((files) => {
     const filesWithDefaults = files.map(file => ({
@@ -340,12 +342,44 @@ function App() {
                   <h4 className="text-xs font-medium text-gray-700 mb-2">📊 图表显示</h4>
                   <p className="text-xs text-gray-500">上传文件后自动展示所有已配置的指标图表</p>
                 </div>
-                
+
+                <div className="border-t pt-3">
+                  <h4 className="text-xs font-medium text-gray-700 mb-2">步骤对齐</h4>
+                  <div className="space-y-2">
+                    <label className="flex items-center text-xs text-gray-700">
+                      <input
+                        type="checkbox"
+                        className="mr-2"
+                        checked={alignSteps}
+                        onChange={e => setAlignSteps(e.target.checked)}
+                      />
+                      启用基于关键词的步骤对齐
+                    </label>
+                    {alignSteps && (
+                      <div>
+                        <label
+                          htmlFor="step-keyword"
+                          className="block text-xs font-medium text-gray-700 mb-1"
+                        >
+                          关键词
+                        </label>
+                        <input
+                          id="step-keyword"
+                          type="text"
+                          value={stepKeyword}
+                          onChange={e => setStepKeyword(e.target.value)}
+                          className="w-full px-2 py-1 text-xs border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 focus:outline-none"
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+
                 <div className="border-t pt-3">
                   <h4 className="text-xs font-medium text-gray-700 mb-2">基准线设置</h4>
                   <div className="space-y-3">
                     <div>
-                      <label 
+                      <label
                         htmlFor="relative-baseline"
                         className="block text-xs font-medium text-gray-700 mb-1"
                       >
@@ -414,6 +448,8 @@ function App() {
               xRange={xRange}
               onXRangeChange={setXRange}
               onMaxStepChange={setMaxStep}
+              alignSteps={alignSteps}
+              stepKeyword={stepKeyword}
             />
           </section>
         </main>

--- a/src/components/__tests__/ChartContainer.test.jsx
+++ b/src/components/__tests__/ChartContainer.test.jsx
@@ -165,4 +165,35 @@ describe('ChartContainer', () => {
     opts.plugins.zoom.pan.onPanComplete({ chart: { scales: { x: { min: 0, max: 10 } } } });
     opts.plugins.zoom.zoom.onZoomComplete({ chart: { scales: { x: { min: 2, max: 4 } } } });
   });
+
+  it('aligns data points using step keyword when enabled', () => {
+    const onXRangeChange = vi.fn();
+    const onMaxStepChange = vi.fn();
+    const files = [
+      { name: 'a.log', enabled: true, content: 'step:1 loss: 1\nstep:2 loss: 2' },
+      { name: 'b.log', enabled: true, content: 'step:5 loss: 5\nstep:6 loss: 6' }
+    ];
+    const prevCount = __lineProps.length;
+    render(
+      <ChartContainer
+        files={files}
+        metrics={[{ name: 'loss', keyword: 'loss', mode: 'keyword' }]}
+        compareMode="normal"
+        alignSteps
+        stepKeyword="step:"
+        onXRangeChange={onXRangeChange}
+        onMaxStepChange={onMaxStepChange}
+      />
+    );
+
+    const props = __lineProps[prevCount];
+    const dsA = props.data.datasets[0].data;
+    const dsB = props.data.datasets[1].data;
+    expect(dsA[0].x).toBe(1);
+    expect(dsA[1].x).toBe(2);
+    expect(dsB[0].x).toBe(5);
+    expect(dsB[1].x).toBe(6);
+    expect(onXRangeChange).toHaveBeenCalledWith({ min: 1, max: 6 });
+    expect(onMaxStepChange).toHaveBeenCalledWith(6);
+  });
 });


### PR DESCRIPTION
## Summary
- allow aligning log metrics by step keyword
- add UI toggle and keyword input to control step-based alignment
- cover step alignment with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a45e9253b4832dbb7ad42ec9673967