### PR TITLE
feat: add smoothing options to charts

### DIFF
--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -15,6 +15,7 @@ import {
 import zoomPlugin from 'chartjs-plugin-zoom';
 import { ImageDown, Copy, FileDown } from 'lucide-react';
 import { getMinSteps } from "../utils/getMinSteps.js";
+import { applySmoothing } from "../utils/smoothing.js";
 import { useTranslation } from 'react-i18next';
 
 ChartJS.register(
@@ -275,6 +276,10 @@ export default function ChartContainer({
                 }
               }
             });
+          }
+          const smoothingCfg = metric.smoothing || file.config?.smoothing;
+          if (smoothingCfg) {
+            points = applySmoothing(points, smoothingCfg);
           }
           metricsData[metric.name || metric.keyword] = points;
         });

--- a/src/utils/__tests__/smoothing.test.js
+++ b/src/utils/__tests__/smoothing.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { movingAverage, exponentialMovingAverage, applySmoothing } from '../smoothing.js';
+
+describe('smoothing utilities', () => {
+  it('calculates moving average', () => {
+    const data = [
+      { x: 0, y: 1 },
+      { x: 1, y: 2 },
+      { x: 2, y: 3 },
+      { x: 3, y: 4 }
+    ];
+    const result = movingAverage(data, 2);
+    expect(result.map(p => p.y)).toEqual([1, 1.5, 2.5, 3.5]);
+  });
+
+  it('calculates exponential moving average', () => {
+    const data = [
+      { x: 0, y: 1 },
+      { x: 1, y: 2 },
+      { x: 2, y: 3 },
+      { x: 3, y: 4 }
+    ];
+    const result = exponentialMovingAverage(data, 0.5);
+    const expected = [1, 1.5, 2.25, 3.125];
+    result.forEach((p, i) => {
+      expect(p.y).toBeCloseTo(expected[i]);
+    });
+  });
+
+  it('applies smoothing via config', () => {
+    const data = [
+      { x: 0, y: 1 },
+      { x: 1, y: 2 },
+      { x: 2, y: 3 },
+      { x: 3, y: 4 }
+    ];
+    const result = applySmoothing(data, { type: 'movingAverage', windowSize: 2 });
+    expect(result[3].y).toBe(3.5);
+  });
+});

--- a/src/utils/smoothing.js
+++ b/src/utils/smoothing.js
@@ -1,0 +1,38 @@
+export function movingAverage(data, windowSize = 5) {
+  if (!Array.isArray(data) || windowSize <= 1) return data;
+  const result = [];
+  for (let i = 0; i < data.length; i++) {
+    const start = Math.max(0, i - windowSize + 1);
+    const subset = data.slice(start, i + 1);
+    const sum = subset.reduce((acc, p) => acc + p.y, 0);
+    const avg = sum / subset.length;
+    result.push({ x: data[i].x, y: avg });
+  }
+  return result;
+}
+
+export function exponentialMovingAverage(data, alpha = 0.5) {
+  if (!Array.isArray(data) || data.length === 0) return data;
+  const result = [];
+  let prev = data[0].y;
+  result.push({ x: data[0].x, y: prev });
+  for (let i = 1; i < data.length; i++) {
+    const smoothed = alpha * data[i].y + (1 - alpha) * prev;
+    result.push({ x: data[i].x, y: smoothed });
+    prev = smoothed;
+  }
+  return result;
+}
+
+export function applySmoothing(data, config) {
+  if (!config || !config.type) return data;
+  switch (config.type) {
+    case 'movingAverage':
+      return movingAverage(data, config.windowSize || config.window || 5);
+    case 'ema':
+    case 'exponential':
+      return exponentialMovingAverage(data, config.alpha || 0.5);
+    default:
+      return data;
+  }
+}


### PR DESCRIPTION
## Summary
- add moving average and exponential smoothing helpers
- apply optional smoothing during chart data generation
- cover smoothing utilities with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d03a77c832db5027f0c3b8513e5